### PR TITLE
fix: use nobody user instead of 99 uid

### DIFF
--- a/templates/default/exabgp.sh.erb
+++ b/templates/default/exabgp.sh.erb
@@ -4,4 +4,4 @@ touch <%= @env_path %>
 
 mkfifo /run/exabgp.{in,out}
 chmod 600 /run/exabgp.{in,out}
-chown 99:99 /run/exabgp.{in,out}
+chown nobody:nobody /run/exabgp.{in,out}


### PR DESCRIPTION
RHEL8 does not have UID 99 by default.